### PR TITLE
Fix/ N+1 query when checking if news exists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
     test-lint:
         name: Run tests
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v2


### PR DESCRIPTION
When executing `parse_soup_get_featured_news`, was running `check_if_news_exists` with every parsed news, so:

- We have N news
- For each of those N news, we're making 1 separate query
- This results in N queries, but we can get it done in one single query

